### PR TITLE
include "image" in docker-compose

### DIFF
--- a/4_dbt/docker-setup.md
+++ b/4_dbt/docker-setup.md
@@ -21,6 +21,7 @@ Note: You will need your authentication json key file for this method to work. Y
         build:
             context: .
             target: dbt-bigquery
+        image: dbt/bigquery
         volumes:
             - .:/usr/app
             - ~/.dbt/:/root/.dbt/


### PR DESCRIPTION
Hi Ankur! Thanks for sharing this guide. I was following it and got the following error when I run `docker compose build`:

```bash
ERROR: yaml.parser.ParserError: while parsing a block mapping
  in "./docker-compose.yml", line 1, column 1
expected <block end>, but found '<block mapping start>'
  in "./docker-compose.yml", line 2, column 3
```  

Inspecting your own docker-compose.yaml file, I realized there was the "image" section missing in the guide.